### PR TITLE
Fix for DiskArrays.jl v0.4.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SerializedArrays"
 uuid = "621c0da3-e96e-4f80-bd06-5ae31cdfcb39"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"


### PR DESCRIPTION
DiskArrays.jl v0.4.13 defines `PermutedDimsArray(::AbstractDiskArray, perm)` as `PermutedDiskArray`, which broke some code in this package. This works around that design change.